### PR TITLE
Fix import attributes error

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import quickChatData from "../../resources/QuickChat.json" with { type: "json" };
+import quickChatData from "../../resources/QuickChat.json";
 import {
   AllPlayers,
   Difficulty,


### PR DESCRIPTION
## Summary
- avoid TypeScript import attribute by removing `with { type: "json" }`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884ec7536e0832cbd6617716587adf6