### PR TITLE
feat: add road node structure

### DIFF
--- a/resources/images/RoadNodeIcon.svg
+++ b/resources/images/RoadNodeIcon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#999" />
+  <path d="M10 50 H90" stroke="white" stroke-width="10" />
+  <path d="M50 10 V90" stroke="white" stroke-width="10" />
+</svg>

--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -120,6 +120,7 @@ export class ControlPanel2 extends LitElement implements Layer {
     "SAM Launcher": "/images/SamLauncherIconWhite.svg",
     "Air Field": "/images/AirfieldIcon.svg",
     "Defense Post": "/images/ShieldIconWhite.svg",
+    "Road Node": "/images/RoadNodeIcon.svg",
   };
 
   private readonly NukeTypes: UnitType[] = [
@@ -150,6 +151,7 @@ export class ControlPanel2 extends LitElement implements Layer {
     UnitType.Hospital,
     UnitType.Academy,
     UnitType.City,
+    UnitType.RoadNode,
   ];
 
   init() {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -565,6 +565,21 @@ export class DefaultConfig implements Config {
           constructionDuration: this.instantBuild() ? 0 : 2 * 20,
           maxHealth: 750,
         };
+      case UnitType.RoadNode:
+        return {
+          cost: (p: Player) =>
+            p.type() === PlayerType.Human && this.infiniteGold()
+              ? 0n
+              : BigInt(
+                  Math.min(
+                    1_000_000,
+                    Math.pow(2, p.unitsOwned(UnitType.RoadNode)) * 200_000,
+                  ),
+                ),
+          territoryBound: true,
+          constructionDuration: this.instantBuild() ? 0 : 2 * 10,
+          maxHealth: 500,
+        };
       case UnitType.CargoPlane:
         return {
           cost: () => 0n,

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -18,6 +18,7 @@ import { MirvExecution } from "./MIRVExecution";
 import { MissileSiloExecution } from "./MissileSiloExecution";
 import { NukeExecution } from "./NukeExecution";
 import { PortExecution } from "./PortExecution";
+import { RoadNodeExecution } from "./RoadNodeExecution";
 import { SAMLauncherExecution } from "./SAMLauncherExecution";
 import { WarshipExecution } from "./WarshipExecution";
 
@@ -146,6 +147,9 @@ export class ConstructionExecution implements Execution {
         break;
       case UnitType.Airfield:
         this.mg.addExecution(new AirfieldExecution(player, this.tile));
+        break;
+      case UnitType.RoadNode:
+        this.mg.addExecution(new RoadNodeExecution(player, this.tile));
         break;
       default:
         // Try to build the unit directly if it has no specific execution

--- a/src/core/execution/RoadNodeExecution.ts
+++ b/src/core/execution/RoadNodeExecution.ts
@@ -1,0 +1,98 @@
+import {
+  Execution,
+  Game,
+  isStructureType,
+  Player,
+  Unit,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+
+export class RoadNodeExecution implements Execution {
+  private mg: Game;
+  private node: Unit | null = null;
+  private active = true;
+  private roadsBuilt = false;
+
+  constructor(
+    private player: Player,
+    private tile: TileRef,
+  ) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+  }
+
+  tick(ticks: number): void {
+    if (this.node === null) {
+      const spawnTile = this.player.canBuild(UnitType.RoadNode, this.tile);
+      if (spawnTile === false) {
+        console.warn("cannot build road node");
+        this.active = false;
+        return;
+      }
+      this.node = this.player.buildUnit(UnitType.RoadNode, spawnTile, {});
+      this.buildRoads();
+      this.active = false; // no ongoing logic after road placement
+      return;
+    }
+    if (!this.node.isActive()) {
+      this.active = false;
+      return;
+    }
+  }
+
+  private buildRoads() {
+    if (!this.node) return;
+    const radius = 50;
+    const structureTypes = Object.values(UnitType).filter(isStructureType);
+    const nearby = this.mg.nearbyUnits(
+      this.node.tile(),
+      radius,
+      structureTypes,
+    );
+    for (const { unit } of nearby) {
+      if (unit === this.node) continue;
+      const path = this.bresenham(this.node.tile(), unit.tile());
+      for (const t of path) {
+        this.mg.setRoad(t, true);
+      }
+    }
+    this.roadsBuilt = true;
+  }
+
+  private bresenham(a: TileRef, b: TileRef): TileRef[] {
+    const path: TileRef[] = [];
+    let x0 = this.mg.x(a);
+    let y0 = this.mg.y(a);
+    const x1 = this.mg.x(b);
+    const y1 = this.mg.y(b);
+    const dx = Math.abs(x1 - x0);
+    const dy = Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx - dy;
+    while (true) {
+      path.push(this.mg.ref(x0, y0));
+      if (x0 === x1 && y0 === y1) break;
+      const e2 = err * 2;
+      if (e2 > -dy) {
+        err -= dy;
+        x0 += sx;
+      }
+      if (e2 < dx) {
+        err += dx;
+        y0 += sy;
+      }
+    }
+    return path;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -157,6 +157,7 @@ export enum UnitType {
   Hospital = "Hospital",
   Academy = "Academy",
   Airfield = "Air Field",
+  RoadNode = "Road Node",
   CargoPlane = "Cargo Plane",
   Bomber = "Bomber",
   FighterJet = "Fighter Jet", // Represents a Fighter Jet unit.
@@ -172,6 +173,7 @@ const _structureTypes: ReadonlySet<UnitType> = new Set([
   UnitType.Airfield,
   UnitType.Hospital,
   UnitType.Academy,
+  UnitType.RoadNode,
 ]);
 
 export function isStructureType(type: UnitType): boolean {
@@ -232,6 +234,8 @@ export interface UnitParamsMap {
   [UnitType.Construction]: Record<string, never>;
 
   [UnitType.Airfield]: Record<string, never>;
+
+  [UnitType.RoadNode]: Record<string, never>;
 
   [UnitType.CargoPlane]: {
     targetUnit: Unit;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -196,6 +196,14 @@ export class GameImpl implements Game {
     });
   }
 
+  hasRoad(tile: TileRef): boolean {
+    return this._map.hasRoad(tile);
+  }
+
+  setRoad(tile: TileRef, value: boolean) {
+    this._map.setRoad(tile, value);
+  }
+
   units(...types: UnitType[]): Unit[] {
     return Array.from(this._players.values()).flatMap((p) => p.units(...types));
   }

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -27,6 +27,8 @@ export interface GameMap {
   setOwnerID(ref: TileRef, playerId: number): void;
   hasFallout(ref: TileRef): boolean;
   setFallout(ref: TileRef, value: boolean): void;
+  hasRoad(ref: TileRef): boolean;
+  setRoad(ref: TileRef, value: boolean): void;
   isOnEdgeOfMap(ref: TileRef): boolean;
   isBorder(ref: TileRef): boolean;
   neighbors(ref: TileRef): TileRef[];
@@ -55,6 +57,7 @@ export class GameMapImpl implements GameMap {
 
   private readonly terrain: Uint8Array; // Immutable terrain data
   private readonly state: Uint16Array; // Mutable game state
+  private readonly roads: Uint8Array; // Road presence
   private readonly width_: number;
   private readonly height_: number;
 
@@ -92,6 +95,7 @@ export class GameMapImpl implements GameMap {
     this.height_ = height;
     this.terrain = terrainData;
     this.state = new Uint16Array(width * height);
+    this.roads = new Uint8Array(width * height);
     // Precompute the LUTs
     let ref = 0;
     this.refToX = new Array(width * height);
@@ -208,6 +212,14 @@ export class GameMapImpl implements GameMap {
     }
   }
 
+  hasRoad(ref: TileRef): boolean {
+    return Boolean(this.roads[ref]);
+  }
+
+  setRoad(ref: TileRef, value: boolean): void {
+    this.roads[ref] = value ? 1 : 0;
+  }
+
   isOnEdgeOfMap(ref: TileRef): boolean {
     const x = this.x(ref);
     const y = this.y(ref);
@@ -248,6 +260,9 @@ export class GameMapImpl implements GameMap {
   }
 
   cost(ref: TileRef): number {
+    if (this.hasRoad(ref)) {
+      return 0.5;
+    }
     return this.magnitude(ref) < 10 ? 2 : 1;
   }
 

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -592,6 +592,12 @@ export class GameView implements GameMap {
   setFallout(ref: TileRef, value: boolean): void {
     return this._map.setFallout(ref, value);
   }
+  hasRoad(ref: TileRef): boolean {
+    return this._map.hasRoad(ref);
+  }
+  setRoad(ref: TileRef, value: boolean): void {
+    return this._map.setRoad(ref, value);
+  }
   isBorder(ref: TileRef): boolean {
     return this._map.isBorder(ref);
   }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -993,6 +993,7 @@ export class PlayerImpl implements Player {
       case UnitType.Academy:
       case UnitType.Construction:
       case UnitType.Airfield:
+      case UnitType.RoadNode:
         return this.landBasedStructureSpawn(targetTile, validTiles);
       case UnitType.CargoPlane:
       case UnitType.Bomber:


### PR DESCRIPTION
## Summary
- add Road Node unit type and building execution
- allow players to construct road nodes and connect nearby structures with low-cost road paths
- expose new road tiles to pathfinding and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e38cb1478832c9f6b77ba9ef7b1b3