### PR TITLE
Refactor test tick helpers to use async/await

### DIFF
--- a/tests/AllianceExtensionExecution.test.ts
+++ b/tests/AllianceExtensionExecution.test.ts
@@ -50,7 +50,7 @@ describe("AllianceExtensionExecution", () => {
 
     let safety = 0;
     while (game.inSpawnPhase() && safety++ < 500) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
     expect(safety).toBeLessThan(500); // Sanity check
 
@@ -61,21 +61,21 @@ describe("AllianceExtensionExecution", () => {
       new PlayerExecution(player1),
       new PlayerExecution(player2),
     );
-    game.executeNextTick();
+    await game.executeNextTick();
   });
 
-  test("Successfully extends existing alliance", () => {
+  test("Successfully extends existing alliance", async () => {
     jest.spyOn(player1, "canSendAllianceRequest").mockReturnValue(true);
     game.addExecution(new AllianceRequestExecution(player1, player2.id()));
-    game.executeNextTick(); // toevoegen
-    game.executeNextTick(); // uitvoeren
+    await game.executeNextTick(); // toevoegen
+    await game.executeNextTick(); // uitvoeren
 
     // 2. Accept alliance request
     game.addExecution(
       new AllianceRequestReplyExecution(player1.id(), player2, true),
     );
-    game.executeNextTick(); // add
-    game.executeNextTick(); // execute
+    await game.executeNextTick(); // add
+    await game.executeNextTick(); // execute
 
     // ✅ After accepting, both players should have an alliance
     expect(player1.allianceWith(player2)).toBeTruthy();
@@ -87,7 +87,7 @@ describe("AllianceExtensionExecution", () => {
 
     // 3. Extend the alliance
     game.addExecution(new AllianceExtensionExecution(player1, player2));
-    game.executeNextTick();
+    await game.executeNextTick();
 
     const allianceAfter = player1.allianceWith(player2)!;
 
@@ -100,9 +100,9 @@ describe("AllianceExtensionExecution", () => {
     expect(expirationAfter).toBeGreaterThanOrEqual(expirationBefore);
   });
 
-  test("Fails gracefully if no alliance exists", () => {
+  test("Fails gracefully if no alliance exists", async () => {
     game.addExecution(new AllianceExtensionExecution(player1, player2));
-    game.executeNextTick();
+    await game.executeNextTick();
 
     expect(player1.allianceWith(player2)).toBeFalsy();
     expect(player2.allianceWith(player1)).toBeFalsy();

--- a/tests/Attack.test.ts
+++ b/tests/Attack.test.ts
@@ -58,7 +58,7 @@ describe("Attack", () => {
     );
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     attacker = game.player(attackerInfo.id);
@@ -67,9 +67,9 @@ describe("Attack", () => {
     game.addExecution(
       new AttackExecution(100, defender, game.terraNullius().id()),
     );
-    game.executeNextTick();
+    await game.executeNextTick();
     while (defender.outgoingAttacks().length > 0) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     (game.config() as TestConfig).setDefaultNukeSpeed(50);
@@ -78,10 +78,10 @@ describe("Attack", () => {
   test("Nuke reduce attacking troop counts", async () => {
     // Not building exactly spawn to it's better protected from attacks (but still
     // on defender territory)
-    constructionExecution(game, defender, 1, 1, UnitType.MissileSilo);
+    await constructionExecution(game, defender, 1, 1, UnitType.MissileSilo);
     expect(defender.units(UnitType.MissileSilo)).toHaveLength(1);
     game.addExecution(new AttackExecution(100, attacker, defender.id()));
-    constructionExecution(game, defender, 0, 15, UnitType.AtomBomb, 3);
+    await constructionExecution(game, defender, 0, 15, UnitType.AtomBomb, 3);
     const nuke = defender.units(UnitType.AtomBomb)[0];
     expect(nuke.isActive()).toBe(true);
 
@@ -89,26 +89,26 @@ describe("Attack", () => {
     expect(attacker.outgoingAttacks()[0].troops()).toBe(98);
 
     // Make the nuke go kaboom
-    game.executeNextTick();
+    await game.executeNextTick();
     expect(nuke.isActive()).toBe(false);
     expect(attacker.outgoingAttacks()[0].troops()).not.toBe(97);
     expect(attacker.outgoingAttacks()[0].troops()).toBeLessThan(90);
   });
 
   test("Nuke reduce attacking boat troop count", async () => {
-    constructionExecution(game, defender, 1, 1, UnitType.MissileSilo);
+    await constructionExecution(game, defender, 1, 1, UnitType.MissileSilo);
     expect(defender.units(UnitType.MissileSilo)).toHaveLength(1);
 
     sendBoat(game.ref(15, 8), game.ref(10, 5), 100);
 
-    constructionExecution(game, defender, 0, 15, UnitType.AtomBomb, 3);
+    await constructionExecution(game, defender, 0, 15, UnitType.AtomBomb, 3);
     const nuke = defender.units(UnitType.AtomBomb)[0];
     expect(nuke.isActive()).toBe(true);
 
     const ship = defender.units(UnitType.TransportShip)[0];
     expect(ship.troops()).toBe(100);
 
-    game.executeNextTick();
+    await game.executeNextTick();
 
     expect(nuke.isActive()).toBe(false);
     expect(defender.units(UnitType.TransportShip)[0].troops()).toBeLessThan(90);

--- a/tests/Disconnected.test.ts
+++ b/tests/Disconnected.test.ts
@@ -40,7 +40,7 @@ describe("Disconnected", () => {
     );
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
   });
 
@@ -82,9 +82,9 @@ describe("Disconnected", () => {
       expect(updatedPlayer2View.isDisconnected()).toBe(false);
     });
 
-    test("should maintain disconnected state in view across game ticks", () => {
+    test("should maintain disconnected state in view across game ticks", async () => {
       player2.markDisconnected(true);
-      executeTicks(game, 3);
+      await executeTicks(game, 3);
 
       const player2View = game.player(player2.id());
       expect(player2View.isDisconnected()).toBe(true);
@@ -92,19 +92,19 @@ describe("Disconnected", () => {
   });
 
   describe("MarkDisconnectedExecution", () => {
-    test("should mark player as disconnected when executed", () => {
+    test("should mark player as disconnected when executed", async () => {
       const execution = new MarkDisconnectedExecution(player1, true);
       game.addExecution(execution);
-      executeTicks(game, 1);
+      await executeTicks(game, 1);
       expect(player1.isDisconnected()).toBe(true);
       expect(execution.isActive()).toBe(false);
     });
 
-    test("should handle multiple players with different disconnected states", () => {
+    test("should handle multiple players with different disconnected states", async () => {
       const execution1 = new MarkDisconnectedExecution(player1, true);
       const execution2 = new MarkDisconnectedExecution(player2, false);
       game.addExecution(execution1, execution2);
-      executeTicks(game, 1);
+      await executeTicks(game, 1);
       expect(player1.isDisconnected()).toBe(true);
       expect(player2.isDisconnected()).toBe(false);
     });
@@ -114,26 +114,26 @@ describe("Disconnected", () => {
       expect(execution.activeDuringSpawnPhase()).toBe(false);
     });
 
-    test("should handle multiple executions for same player in same tick", () => {
+    test("should handle multiple executions for same player in same tick", async () => {
       const execution1 = new MarkDisconnectedExecution(player1, true);
       const execution2 = new MarkDisconnectedExecution(player1, false);
       game.addExecution(execution1, execution2);
-      executeTicks(game, 1);
+      await executeTicks(game, 1);
       // Last execution should win
       expect(player1.isDisconnected()).toBe(false);
     });
   });
 
   describe("Disconnected state persistence", () => {
-    test("should maintain disconnected state across game ticks", () => {
+    test("should maintain disconnected state across game ticks", async () => {
       player1.markDisconnected(true);
-      executeTicks(game, 5);
+      await executeTicks(game, 5);
       expect(player1.isDisconnected()).toBe(true);
     });
 
-    test("should maintain disconnected state in player updates across ticks", () => {
+    test("should maintain disconnected state in player updates across ticks", async () => {
       player1.markDisconnected(true);
-      executeTicks(game, 3);
+      await executeTicks(game, 3);
       const update = player1.toUpdate();
       expect(update.isDisconnected).toBe(true);
     });
@@ -152,11 +152,11 @@ describe("Disconnected", () => {
       expect(player1.isDisconnected()).toBe(false);
     });
 
-    test("should handle execution with same disconnected state", () => {
+    test("should handle execution with same disconnected state", async () => {
       player1.markDisconnected(true);
       const execution = new MarkDisconnectedExecution(player1, true);
       game.addExecution(execution);
-      executeTicks(game, 1);
+      await executeTicks(game, 1);
       expect(player1.isDisconnected()).toBe(true);
     });
   });

--- a/tests/MissileSilo.test.ts
+++ b/tests/MissileSilo.test.ts
@@ -14,7 +14,7 @@ import { constructionExecution } from "./util/utils";
 let game: Game;
 let attacker: Player;
 
-function attackerBuildsNuke(
+async function attackerBuildsNuke(
   source: TileRef | null,
   target: TileRef,
   initialize = true,
@@ -23,8 +23,8 @@ function attackerBuildsNuke(
     new NukeExecution(UnitType.AtomBomb, attacker, target, source),
   );
   if (initialize) {
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
   }
 }
 
@@ -45,47 +45,47 @@ describe("MissileSilo", () => {
     );
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     attacker = game.player("attacker_id");
 
-    constructionExecution(game, attacker, 1, 1, UnitType.MissileSilo);
+    await constructionExecution(game, attacker, 1, 1, UnitType.MissileSilo);
   });
 
   test("missilesilo should launch nuke", async () => {
-    attackerBuildsNuke(null, game.ref(7, 7));
+    await attackerBuildsNuke(null, game.ref(7, 7));
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(1);
     expect(attacker.units(UnitType.AtomBomb)[0].tile()).not.toBe(
       game.map().ref(7, 7),
     );
 
     for (let i = 0; i < 5; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(0);
   });
 
   test("missilesilo should only launch one nuke at a time", async () => {
-    attackerBuildsNuke(null, game.ref(7, 7));
-    attackerBuildsNuke(null, game.ref(7, 7));
+    await attackerBuildsNuke(null, game.ref(7, 7));
+    await attackerBuildsNuke(null, game.ref(7, 7));
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(1);
   });
 
   test("missilesilo should cooldown as long as configured", async () => {
     expect(attacker.units(UnitType.MissileSilo)[0].isInCooldown()).toBeFalsy();
     // send the nuke far enough away so it doesnt destroy the silo
-    attackerBuildsNuke(null, game.ref(50, 50));
+    await attackerBuildsNuke(null, game.ref(50, 50));
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(1);
 
     for (let i = 0; i < game.config().SiloCooldown() - 2; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
       expect(
         attacker.units(UnitType.MissileSilo)[0].isInCooldown(),
       ).toBeTruthy();
     }
 
-    game.executeNextTick();
+    await game.executeNextTick();
     expect(attacker.units(UnitType.MissileSilo)[0].isInCooldown()).toBeFalsy();
   });
 });

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -36,7 +36,7 @@ describe("Stats", () => {
     ]);
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     player1 = game.player("player_1_id");

--- a/tests/TerritoryCapture.test.ts
+++ b/tests/TerritoryCapture.test.ts
@@ -13,9 +13,9 @@ describe("Territory management", () => {
       new SpawnExecution(game.player("test_id").info(), spawnTile),
     );
     // Init the execution
-    game.executeNextTick();
+    await game.executeNextTick();
     // Execute the execution.
-    game.executeNextTick();
+    await game.executeNextTick();
 
     const owner = game.owner(spawnTile);
     expect(owner.isPlayer()).toBe(true);

--- a/tests/Warship.test.ts
+++ b/tests/Warship.test.ts
@@ -42,7 +42,7 @@ describe("Warship", () => {
     );
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     player1 = game.player("player_1_id");
@@ -66,17 +66,17 @@ describe("Warship", () => {
     );
     game.addExecution(new WarshipExecution(warship));
 
-    game.executeNextTick();
+    await game.executeNextTick();
 
     expect(warship.health()).toBe(maxHealth);
     warship.modifyHealth(-10);
     expect(warship.health()).toBe(maxHealth - 10);
-    game.executeNextTick();
+    await game.executeNextTick();
     expect(warship.health()).toBe(maxHealth - 9);
 
     port.delete();
 
-    game.executeNextTick();
+    await game.executeNextTick();
     expect(warship.health()).toBe(maxHealth - 9);
   });
 
@@ -102,7 +102,7 @@ describe("Warship", () => {
     expect(tradeShip.owner().id()).toBe(player2.id());
     // Let plenty of time for A* to execute
     for (let i = 0; i < 10; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
     expect(tradeShip.owner()).toBe(player1);
   });
@@ -127,7 +127,7 @@ describe("Warship", () => {
     expect(tradeShip.owner().id()).toBe(player2.id());
     // Let plenty of time for warship to potentially capture trade ship
     for (let i = 0; i < 10; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     expect(tradeShip.owner().id()).toBe(player2.id());
@@ -156,7 +156,7 @@ describe("Warship", () => {
 
     tradeShip.setSafeFromPirates();
 
-    executeTicks(game, 10);
+    await executeTicks(game, 10);
 
     expect(tradeShip.owner().id()).toBe(player2.id());
   });
@@ -178,7 +178,7 @@ describe("Warship", () => {
       new MoveWarshipExecution(player1, warship.id(), game.ref(coastX + 5, 15)),
     );
 
-    executeTicks(game, 10);
+    await executeTicks(game, 10);
 
     expect(warship.patrolTile()).toBe(game.ref(coastX + 5, 15));
   });
@@ -206,7 +206,7 @@ describe("Warship", () => {
       },
     );
 
-    executeTicks(game, 10);
+    await executeTicks(game, 10);
 
     // Trade ship should not be captured
     expect(tradeShip.owner().id()).toBe(player2.id());

--- a/tests/core/executions/NukeExecution.test.ts
+++ b/tests/core/executions/NukeExecution.test.ts
@@ -44,7 +44,7 @@ describe("NukeExecution", () => {
     (game.config() as TestConfig).nukeAllianceBreakThreshold = jest.fn(() => 5);
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     player = game.player("player_id");
@@ -75,7 +75,7 @@ describe("NukeExecution", () => {
     );
     game.addExecution(nukeExec);
     // Run enough ticks for the nuke to detonate
-    executeTicks(game, 10);
+    await executeTicks(game, 10);
     // The city and silo should be destroyed
     expect(player.units(UnitType.City)).toHaveLength(0);
     expect(player.units(UnitType.MissileSilo)).toHaveLength(0);
@@ -95,15 +95,15 @@ describe("NukeExecution", () => {
     // targetable distance is 400
 
     //near launch should be targetable (distance src < 400)
-    executeTicks(game, 2);
+    await executeTicks(game, 2);
     expect(nukeExec.getNuke()!.isTargetable()).toBeTruthy();
 
     //mid air should not be targetable (distance src > 400, distance target > 400)
-    executeTicks(game, 38);
+    await executeTicks(game, 38);
     expect(nukeExec.getNuke()!.isTargetable()).toBeFalsy();
 
     //near target should be targetable (distance target < 400)
-    executeTicks(game, 35);
+    await executeTicks(game, 35);
     expect(nukeExec.getNuke()!.isTargetable()).toBeTruthy();
   });
 
@@ -125,8 +125,8 @@ describe("NukeExecution", () => {
       new NukeExecution(UnitType.AtomBomb, player, game.ref(85, 85), null),
     );
 
-    game.executeNextTick(); // init
-    game.executeNextTick(); // exec
+    await game.executeNextTick(); // init
+    await game.executeNextTick(); // exec
 
     expect(player.isTraitor()).toBe(true);
     expect(player.isAlliedWith(otherPlayer)).toBe(false);

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -67,7 +67,7 @@ describe("SAM", () => {
     );
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     attacker = game.player("attacker_id");
@@ -75,7 +75,7 @@ describe("SAM", () => {
     middle_defender = game.player("middle_defender_id");
     far_defender = game.player("far_defender_id");
 
-    constructionExecution(game, attacker, 7, 7, UnitType.MissileSilo);
+    await constructionExecution(game, attacker, 7, 7, UnitType.MissileSilo);
   });
 
   test("one sam should take down one nuke", async () => {
@@ -85,7 +85,7 @@ describe("SAM", () => {
       targetTile: game.ref(2, 1),
     });
 
-    executeTicks(game, 3);
+    await executeTicks(game, 3);
 
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(0);
   });
@@ -101,7 +101,7 @@ describe("SAM", () => {
     });
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(2);
 
-    executeTicks(game, 3);
+    await executeTicks(game, 3);
 
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(1);
   });
@@ -114,15 +114,15 @@ describe("SAM", () => {
       targetTile: game.ref(1, 2),
     });
 
-    executeTicks(game, 3);
+    await executeTicks(game, 3);
 
     expect(nuke.isActive()).toBeFalsy();
     for (let i = 0; i < game.config().SAMNukeCooldown() - 3; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
       expect(sam.isInCooldown()).toBeTruthy();
     }
 
-    executeTicks(game, 2);
+    await executeTicks(game, 2);
 
     expect(sam.isInCooldown()).toBeFalsy();
   });
@@ -136,7 +136,7 @@ describe("SAM", () => {
       targetTile: game.ref(2, 2),
     });
 
-    executeTicks(game, 3);
+    await executeTicks(game, 3);
 
     expect(nuke.isActive()).toBeFalsy();
     expect([sam1, sam2].filter((s) => s.isInCooldown())).toHaveLength(1);
@@ -159,7 +159,7 @@ describe("SAM", () => {
     const ticksToExecute = Math.ceil(
       targetDistance / game.config().defaultNukeSpeed(),
     );
-    executeTicks(game, ticksToExecute);
+    await executeTicks(game, ticksToExecute);
 
     expect(nukeExecution.isActive()).toBeFalsy();
     expect(sam.isInCooldown()).toBeTruthy();
@@ -194,7 +194,7 @@ describe("SAM", () => {
     const ticksToExecute = Math.ceil(
       targetDistance / game.config().defaultNukeSpeed(),
     );
-    executeTicks(game, ticksToExecute);
+    await executeTicks(game, ticksToExecute);
     expect(nukeExecution.isActive()).toBeFalsy();
     expect(sam1.isInCooldown()).toBeFalsy();
     expect(sam2.isInCooldown()).toBeTruthy();

--- a/tests/core/game/CargoManager.test.ts
+++ b/tests/core/game/CargoManager.test.ts
@@ -52,7 +52,7 @@ describe("CargoManager", () => {
 
     // Let roads form
     for (let i = 0; i < 200; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
     expect(game.roads().length).toBeGreaterThan(0);
   });
@@ -61,7 +61,7 @@ describe("CargoManager", () => {
     jest.restoreAllMocks();
   });
 
-  it("spawns, moves, and completes domestic cargo trucks once roads exist", () => {
+  it("spawns, moves, and completes domestic cargo trucks once roads exist", async () => {
     // Force deterministic spawning and selection
     jest.spyOn(PseudoRandom.prototype, "chance").mockReturnValue(true);
     jest
@@ -71,19 +71,19 @@ describe("CargoManager", () => {
     // Align with player's spawn bucket (deterministic based on player id)
     const bucket = simpleHash(player.id()) % 10;
     while (game.ticks() % 10 !== bucket) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     const goldBefore = player.gold();
 
     // This tick should spawn at least one truck
-    let updates = game.executeNextTick();
+    let updates = await game.executeNextTick();
     const { added } = collectCargo(updates);
     expect(added.length).toBeGreaterThan(0);
     const truckId = added[0].id;
 
     // Next tick: truck should move (progress increases)
-    updates = game.executeNextTick();
+    updates = await game.executeNextTick();
     const { updated } = collectCargo(updates);
     const moved = updated.find((u) => u.id === truckId);
     expect(moved).toBeDefined();
@@ -92,7 +92,7 @@ describe("CargoManager", () => {
     // Keep ticking until the truck arrives and is removed
     let removedSeen = false;
     for (let i = 0; i < 100 && !removedSeen; i++) {
-      updates = game.executeNextTick();
+      updates = await game.executeNextTick();
       const { removed } = collectCargo(updates);
       removedSeen = removed.includes(truckId);
     }
@@ -102,7 +102,7 @@ describe("CargoManager", () => {
     expect(goldAfter > goldBefore).toBe(true);
   });
 
-  it("emits periodic domestic trade summary messages with accumulated gold", () => {
+  it("emits periodic domestic trade summary messages with accumulated gold", async () => {
     // Force deterministic spawning and selection
     jest.spyOn(PseudoRandom.prototype, "chance").mockReturnValue(true);
     jest
@@ -113,7 +113,7 @@ describe("CargoManager", () => {
     // and ensure some trucks have completed by then.
     let sawSummary = false;
     for (let i = 0; i < 400 && !sawSummary; i++) {
-      const updates = game.executeNextTick();
+      const updates = await game.executeNextTick();
       const messages = updates[GameUpdateType.DisplayEvent] as any[];
       if (
         messages.some(

--- a/tests/core/game/GameImpl.test.ts
+++ b/tests/core/game/GameImpl.test.ts
@@ -51,7 +51,7 @@ describe("GameImpl", () => {
     );
 
     while (game.inSpawnPhase()) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
 
     attacker = game.player(attackerInfo.id);
@@ -62,15 +62,15 @@ describe("GameImpl", () => {
     jest.spyOn(attacker, "canSendAllianceRequest").mockReturnValue(true);
     game.addExecution(new AllianceRequestExecution(attacker, defender.id()));
 
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
 
     game.addExecution(
       new AllianceRequestReplyExecution(attacker.id(), defender, true),
     );
 
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
 
     expect(attacker.allianceWith(defender)).toBeTruthy();
     expect(defender.allianceWith(attacker)).toBeTruthy();
@@ -78,13 +78,13 @@ describe("GameImpl", () => {
     //Defender is marked disconnected
     defender.markDisconnected(true);
 
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
 
     game.addExecution(new AttackExecution(100, attacker, defender.id()));
 
     do {
-      game.executeNextTick();
+      await game.executeNextTick();
     } while (attacker.outgoingAttacks().length > 0);
 
     expect(attacker.isTraitor()).toBe(false);
@@ -94,28 +94,28 @@ describe("GameImpl", () => {
     jest.spyOn(attacker, "canSendAllianceRequest").mockReturnValue(true);
     game.addExecution(new AllianceRequestExecution(attacker, defender.id()));
 
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
 
     game.addExecution(
       new AllianceRequestReplyExecution(attacker.id(), defender, true),
     );
 
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
 
     expect(attacker.allianceWith(defender)).toBeTruthy();
     expect(defender.allianceWith(attacker)).toBeTruthy();
 
     //Defender is NOT marked disconnected
 
-    game.executeNextTick();
-    game.executeNextTick();
+    await game.executeNextTick();
+    await game.executeNextTick();
 
     game.addExecution(new AttackExecution(100, attacker, defender.id()));
 
     do {
-      game.executeNextTick();
+      await game.executeNextTick();
     } while (attacker.outgoingAttacks().length > 0);
 
     expect(attacker.isTraitor()).toBe(true);

--- a/tests/core/game/RoadManager.test.ts
+++ b/tests/core/game/RoadManager.test.ts
@@ -23,7 +23,7 @@ describe("RoadManager", () => {
     roadManager = (game as any).roadManager;
   });
 
-  it("should form a road between two cities for a player with the Roads upgrade", () => {
+  it("should form a road between two cities for a player with the Roads upgrade", async () => {
     playerA.addUpgrade(UpgradeType.Roads);
 
     const tile1 = game.ref(0, 10);
@@ -39,7 +39,7 @@ describe("RoadManager", () => {
 
     const city1 = playerA.buildUnit(UnitType.City, tile1, {});
     const city2 = playerA.buildUnit(UnitType.City, tile2, {});
-    executeTicks(game, 15);
+    await executeTicks(game, 15);
 
     const roads = (roadManager as any).roads;
     expect(roads.size).toBeGreaterThan(0);
@@ -51,7 +51,7 @@ describe("RoadManager", () => {
     expect((roadManager as any).existingRoadSegments.has(segment)).toBe(true);
   });
 
-  it("should NOT form a road if the player does not have the Roads upgrade", () => {
+  it("should NOT form a road if the player does not have the Roads upgrade", async () => {
     const tile1 = game.ref(0, 10);
     const tile2 = game.ref(0, 15);
     game.conquer(playerA as PlayerImpl, tile1);
@@ -59,13 +59,13 @@ describe("RoadManager", () => {
 
     playerA.buildUnit(UnitType.City, tile1, {});
     playerA.buildUnit(UnitType.City, tile2, {});
-    executeTicks(game, 15);
+    await executeTicks(game, 15);
 
     const roads = (roadManager as any).roads;
     expect(roads.size).toBe(0);
   });
 
-  it("destroyPlayerRoads should clear all road state for a player", () => {
+  it("destroyPlayerRoads should clear all road state for a player", async () => {
     playerA.addUpgrade(UpgradeType.Roads);
     const tile1 = game.ref(0, 10);
     const tile2 = game.ref(0, 15);
@@ -75,7 +75,7 @@ describe("RoadManager", () => {
 
     const city1 = playerA.buildUnit(UnitType.City, tile1, {});
     const city2 = playerA.buildUnit(UnitType.City, tile2, {});
-    executeTicks(game, 15);
+    await executeTicks(game, 15);
     expect((roadManager as any).roads.size).toBeGreaterThan(0);
 
     const segment = (roadManager as any).getCanonicalSegment(
@@ -94,7 +94,7 @@ describe("RoadManager", () => {
     expect(edge).toBeUndefined();
   });
 
-  it("should rebuild the road network after using markPlayerNodesForReconnection", () => {
+  it("should rebuild the road network after using markPlayerNodesForReconnection", async () => {
     playerA.addUpgrade(UpgradeType.Roads);
     const tile1 = game.ref(0, 10);
     const tile2 = game.ref(0, 15);
@@ -104,7 +104,7 @@ describe("RoadManager", () => {
 
     playerA.buildUnit(UnitType.City, tile1, {});
     playerA.buildUnit(UnitType.City, tile2, {});
-    executeTicks(game, 15);
+    await executeTicks(game, 15);
     expect((roadManager as any).roads.size).toBeGreaterThan(0);
 
     roadManager.destroyPlayerRoads(playerA);
@@ -113,7 +113,7 @@ describe("RoadManager", () => {
     // Re-add the upgrade before marking for reconnection
     playerA.addUpgrade(UpgradeType.Roads);
     roadManager.markPlayerNodesForReconnection(playerA);
-    executeTicks(game, 15);
+    await executeTicks(game, 15);
 
     expect((roadManager as any).roads.size).toBeGreaterThan(0);
   });

--- a/tests/integrations/ScorchedEarth.test.ts
+++ b/tests/integrations/ScorchedEarth.test.ts
@@ -28,7 +28,7 @@ describe("Scorched Earth Full Cycle Integration Test", () => {
     // Step 1: Buy Roads and verify network creation
     game.addExecution(new PurchaseUpgradeExecution(player, UpgradeType.Roads));
     for (let i = 0; i < 200; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
     expect(game.roads().length).toBeGreaterThan(0);
 
@@ -36,14 +36,14 @@ describe("Scorched Earth Full Cycle Integration Test", () => {
     game.addExecution(
       new PurchaseUpgradeExecution(player, UpgradeType.ScorchedEarth),
     );
-    game.executeNextTick();
+    await game.executeNextTick();
     expect(game.roads().length).toBe(0);
     expect(player.hasUpgrade(UpgradeType.Roads)).toBe(false);
 
     // Step 3: Re-buy Roads and verify network reformation
     game.addExecution(new PurchaseUpgradeExecution(player, UpgradeType.Roads));
     for (let i = 0; i < 20; i++) {
-      game.executeNextTick();
+      await game.executeNextTick();
     }
     expect(game.roads().length).toBeGreaterThan(0);
   });

--- a/tests/util/utils.ts
+++ b/tests/util/utils.ts
@@ -7,7 +7,7 @@ import { ConstructionExecution } from "../../src/core/execution/ConstructionExec
 import { Game, Player, UnitType } from "../../src/core/game/Game";
 
 // built via UI (e.g.: trade ships)
-export function constructionExecution(
+export async function constructionExecution(
   game: Game,
   _owner: Player,
   x: number,
@@ -25,12 +25,15 @@ export function constructionExecution(
   // (sometimes step 3 and 4 are merged in one)
 
   for (let i = 0; i < ticks; i++) {
-    game.executeNextTick();
+    await game.executeNextTick();
   }
 }
 
-export function executeTicks(game: Game, numTicks: number): void {
+export async function executeTicks(
+  game: Game,
+  numTicks: number,
+): Promise<void> {
   for (let i = 0; i < numTicks; i++) {
-    game.executeNextTick();
+    await game.executeNextTick();
   }
 }


### PR DESCRIPTION
## Summary
- make the `constructionExecution` and `executeTicks` test helpers async and await each simulated tick
- update affected tests to await spawn-phase loops and per-tick updates before making assertions
- ensure cargo manager and other suites await tick results before reading emitted update maps

## Testing
- npm test *(fails: Jest environment cannot handle Worker import.meta modules and CanvasRenderingContext2D, plus perf benchmark budget check)*

------
https://chatgpt.com/codex/tasks/task_b_68cebe9e83c4832c92de0673d403bbc5