### PR TITLE
Update PurchaseUpgradeExecution roads test

### DIFF
--- a/tests/core/execution/PurchaseUpgradeExecution.test.ts
+++ b/tests/core/execution/PurchaseUpgradeExecution.test.ts
@@ -25,7 +25,7 @@ describe("PurchaseUpgradeExecution", () => {
         }),
       }),
       destroyPlayerRoads: jest.fn(),
-      markPlayerNodesForReconnection: jest.fn(),
+      buildInitialRoadNetwork: jest.fn(),
     } as unknown as jest.Mocked<GameImpl>;
   });
 
@@ -88,8 +88,6 @@ describe("PurchaseUpgradeExecution", () => {
     const exec = new PurchaseUpgradeExecution(mockPlayer, UpgradeType.Roads);
     exec.init(mockGame, 0);
 
-    expect(mockGame.markPlayerNodesForReconnection).toHaveBeenCalledWith(
-      mockPlayer,
-    );
+    expect(mockGame.buildInitialRoadNetwork).toHaveBeenCalledWith(mockPlayer);
   });
 });


### PR DESCRIPTION
## Summary
- update the mocked GameImpl in PurchaseUpgradeExecution tests to include buildInitialRoadNetwork
- verify roads purchases trigger buildInitialRoadNetwork instead of markPlayerNodesForReconnection

## Testing
- npm test -- PurchaseUpgradeExecution

------
https://chatgpt.com/codex/tasks/task_b_68cebec197a0832ca49dcd294ae7e17f